### PR TITLE
Add a variable to make memory available to varnish configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -78,4 +78,7 @@ vanrish_corefile_limit: "unlimited"
 # use Alternative 3, Advanced configuration, below
 #RELOAD_VCL: 1
 
+# Size of memory available to varnish. Default is 256m
+varnish_memory: "256m"
+
 # tbd

--- a/templates/etc/default/varnish.j2
+++ b/templates/etc/default/varnish.j2
@@ -22,4 +22,4 @@ DAEMON_OPTS="-a {{ varnish_server_bind_address }}:{{ varnish_server_port }} \
              -T {{ varnish_admin_bind_address }}:{{ varnish_admin_port }} \
              -f /etc/varnish/default.vcl \
              -S /etc/varnish/secret \
-             -s malloc,256m"
+             -s malloc,{{ varnish_memory }}"


### PR DESCRIPTION
Adding a variable to allow easy changing the default of 256MB available to varnish by default.
