### PR TITLE
Add tag and restart on config change

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,7 +44,8 @@
     owner: root
     group: root
     mode: 0644
-  notify: [ 'Restart ferm' ]
+  notify: [ 'Restart varnish', 'Restart ferm' ]
+  tags: [ 'role::varnish:config' ]
 
 - name: Install Debian systemd service unit
   template:


### PR DESCRIPTION
When changing the default config, varnish should be restarted as well.
